### PR TITLE
Update to use inara docker image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,11 +13,12 @@ inputs:
     default: 'paper.md'
 runs:
   using: docker
-  image: 'docker://openjournals/paperdraft:latest'
+  image: 'docker://openjournals/inara:latest'
   env:
     GIT_SHA: $GITHUB_SHA
     JOURNAL: ${{ inputs.journal }}
   args:
+    - -o pdf
     - ${{ inputs.paper-path }}
 branding:
   icon: file-text


### PR DESCRIPTION
This PR makes the GitHub action use the same docker image as the reviews

Closes #5 