### PR TITLE
Add instructions for automated PDF Draft upload 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ jobs:
 This will build the paper.pdf and make it available as an artifact
 after each build.
 
+If you would like to store the PDF in your repository after the build, you need to (1) enable repository write access for your Actions under _Settings/Actions/General/WorkflowPermissions_ and (2) add a step which will `git add` and `git commit` it within the workflow. You can do the latter manually, or wiht a predefined action, e.g. `EndBug/add-and-commit`, by appending `steps` in `draft-pdf.yml` with:
+
+``` yaml
+    - name: Commit PDF to repository
+      uses: EndBug/add-and-commit@v9
+      with:
+        message: '(auto) Paper PDF Draft'
+        # This should be the path to the paper within your repo.
+        add: 'paper.pdf' # 'paper/*.pdf' to commit all PDFs in the paper directory
+```              
+
 Inputs
 ------
 


### PR DESCRIPTION
- Based on my personal needs and looking at a couple of repos for papers recently published in JOSS, people in the community like to upload the generated PDF Drafts into their repos after they are generated, but they do it manually.
- This small PR adds instructions to `README` on how to do it automatically within the `draft-pdf.yml` workflow.