### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
           # This should be the path to the paper within your repo.
           paper-path: paper.md
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled


### PR DESCRIPTION
[As per GitHub](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), v3 of upload-artifact will not be supported from November 2024 forwards. This updates the action to v4, which does not require any changes to the interface used in this repository.